### PR TITLE
fix: update lockfile specifiers and reorder release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,12 @@ jobs:
 
       - run: pnpm run build
 
-      - run: pnpm publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - run: gh release create ${{ github.ref_name }} --generate-notes
+      - name: Create GitHub Release
+        run: gh release create ${{ github.ref_name }} --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,53 +9,53 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.26.0
+        specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       gray-matter:
-        specifier: 4.0.3
+        specifier: ^4.0.3
         version: 4.0.3
       vscode-languageserver:
-        specifier: 9.0.1
+        specifier: ^9.0.1
         version: 9.0.1
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
+        specifier: ^1.0.12
         version: 1.0.12
       zod:
-        specifier: 4.3.6
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@eslint/js':
-        specifier: 9.39.2
+        specifier: ^9.39.2
         version: 9.39.2
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
       '@vitest/coverage-v8':
-        specifier: 4.0.18
+        specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.2.3)(tsx@4.21.0))
       eslint:
-        specifier: 9.39.2
+        specifier: ^9.39.2
         version: 9.39.2
       eslint-config-prettier:
-        specifier: 10.1.8
+        specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2)
       globals:
-        specifier: 17.3.0
+        specifier: ^17.3.0
         version: 17.3.0
       prettier:
-        specifier: 3.8.1
+        specifier: ^3.8.1
         version: 3.8.1
       tsx:
-        specifier: 4.21.0
+        specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: 5.9.3
+        specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: 8.55.0
+        specifier: ^8.55.0
         version: 8.55.0(eslint@9.39.2)(typescript@5.9.3)
       vitest:
-        specifier: 4.0.18
+        specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)
 
 packages:


### PR DESCRIPTION
## Summary
- `pnpm-lock.yaml`의 specifier를 `package.json`의 caret(`^`) 형식과 일치하도록 재생성하여 CI에서 `--frozen-lockfile` 실패를 수정
- `release.yml` 워크플로우에서 GitHub Release 생성을 npm publish보다 먼저 실행하도록 순서 변경

## Context
`v0.5.0` 태그 푸시 시 lockfile specifier 불일치(`1.26.0` vs `^1.26.0`)로 `pnpm install --frozen-lockfile`이 실패하여 릴리즈가 생성되지 않았습니다.

## Test plan
- [ ] PR 머지 후 `v0.5.0` 태그 재생성/푸시하여 Release 워크플로우 성공 확인

Made with [Cursor](https://cursor.com)