### PR TITLE
fix: remove unused imports in AST detectors

### DIFF
--- a/src/core/ast-detectors/access-control.ts
+++ b/src/core/ast-detectors/access-control.ts
@@ -9,7 +9,6 @@ import { registerDetector, type DetectorResult } from "../ast-detector-registry.
 import {
   hasAnyModifier,
   hasModifier,
-  hasModifierLike,
   hasInlineAccessControl,
 } from "../ast-validators.js";
 import { findAllFunctions, hasFunctionCall, findExternalCalls } from "../ast-utils.js";

--- a/src/core/ast-detectors/arithmetic.ts
+++ b/src/core/ast-detectors/arithmetic.ts
@@ -6,7 +6,7 @@
 import { visit } from "@solidity-parser/parser";
 import type { SourceUnit, FunctionCall } from "@solidity-parser/parser/src/ast-types.js";
 import { registerDetector, type DetectorResult } from "../ast-detector-registry.js";
-import { isPragma08OrAbove, isInsideUnchecked } from "../ast-validators.js";
+import { isPragma08OrAbove } from "../ast-validators.js";
 
 function getLine(node: { loc?: { start: { line: number } } }): number {
   return node.loc?.start.line ?? 0;
@@ -15,7 +15,7 @@ function getLine(node: { loc?: { start: { line: number } } }): number {
 registerDetector({
   id: "arithmetic",
   scweIds: ["SCWE-047", "SCWE-074"],
-  detect(ast: SourceUnit, code: string): DetectorResult[] {
+  detect(ast: SourceUnit, _code: string): DetectorResult[] {
     const results: DetectorResult[] = [];
 
     // SCWE-047: Integer overflow — only report if pragma < 0.8

--- a/src/core/ast-detectors/code-quality.ts
+++ b/src/core/ast-detectors/code-quality.ts
@@ -9,7 +9,6 @@ import { registerDetector, type DetectorResult } from "../ast-detector-registry.
 import {
   getPragmaVersion,
   isLibraryOrInterfaceOnly,
-  findFunctionAtLine,
   getFunctionVisibility,
 } from "../ast-validators.js";
 import { findAllFunctions, hasEmitStatement, findStateUpdates } from "../ast-utils.js";

--- a/src/core/ast-detectors/external-calls.ts
+++ b/src/core/ast-detectors/external-calls.ts
@@ -4,12 +4,7 @@
  * insufficient gas griefing, hardcoded gas amounts.
  */
 
-import { visit } from "@solidity-parser/parser";
-import type {
-  SourceUnit,
-  FunctionCall,
-  MemberAccess,
-} from "@solidity-parser/parser/src/ast-types.js";
+import type { SourceUnit } from "@solidity-parser/parser/src/ast-types.js";
 import { registerDetector, type DetectorResult } from "../ast-detector-registry.js";
 import { findAllFunctions, hasDelegatecall, findExternalCalls } from "../ast-utils.js";
 


### PR DESCRIPTION
## Summary
- Remove unused imports flagged by ESLint in 4 AST detector files
- Fixes: `visit`, `FunctionCall`, `MemberAccess` in external-calls.ts; `isInsideUnchecked` + unused `code` param in arithmetic.ts; `hasModifierLike` in access-control.ts; `findFunctionAtLine` in code-quality.ts
- Required for v0.7.0 release CI (lint step was failing)