### PR TITLE
release: v0.8.1 — event emission correctness detector (SCWE-063)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ MCP server + LSP server + 6 Agent Skills for Solidity smart contract security. T
 src/
 ├── index.ts           # MCP entry (wiring only, <=5 lines)
 ├── core/              # Pure analysis logic (CLI wrappers, parsers, AST detectors)
-│   └── ast-detectors/ # 8 AST detector modules (self-registering)
+│   └── ast-detectors/ # 9 AST detector modules (self-registering)
 ├── mcp/               # MCP server: 10 tools, 12 resources, 7 prompts
 ├── lsp/               # LSP server (diagnostics, hover, code actions)
 ├── knowledge/         # OWASP data parsers, vulnerability patterns, style rules
@@ -75,7 +75,7 @@ Two-layer detection: AST detectors (primary) + regex patterns (fallback).
 
 matchPatterns(code, checkIds?)
 → parseSolidity(code) # @solidity-parser/parser + LRU cache
-→ runASTDetectors(ast, code) # 8 detectors, 22 SCWE IDs
+→ runASTDetectors(ast, code) # 9 detectors, 22 SCWE IDs
 → regex fallback (uncovered IDs) # 32 patterns, ~10 SCWE IDs not in AST
 → filterByASTContext() # Phase 2 supplementary FP filter
 → dedup + sort → PatternMatch[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-agent-toolkit",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server providing Solidity smart contract security analysis tools, OWASP knowledge base, and development utilities for AI agents",
   "repository": {
     "type": "git",

--- a/skills/solidity-adversarial-analysis/SKILL.md
+++ b/skills/solidity-adversarial-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial scenario analysis and threat modeling for Solidity smar
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # Solidity Adversarial Scenario Analysis

--- a/skills/solidity-code-review/SKILL.md
+++ b/skills/solidity-code-review/SKILL.md
@@ -114,10 +114,16 @@ Organized by OWASP SCSVS threat model. For each area, verify the listed controls
 - Slippage protection on swaps/liquidity; flash-loan resistance in price-sensitive logic.
 - Oracle manipulation protection (TWAP, multiple sources); no reliance on `address(this).balance` for accounting.
 
-### Events & NatSpec
+### Events & NatSpec (SCWE-063)
 
-- Emit events for all significant state changes; use `indexed` for efficient filtering.
-- Accurate `@notice`, `@param`, `@return`; `@dev` for complex logic and security assumptions.
+Events are the audit trail. Reason about them from the transaction logic, not just syntax — for every state transition an auditor or off-chain indexer would need to follow, verify an event exists, fires, and logs the truth. When one is missing or wrong, propose the correct declaration and `emit`.
+
+- **Missing emission**: every state-changing public/external function emits an event (token transfers, ownership/role changes, config updates, upgrades, fund movements). A silent state change is an audit gap — propose the event.
+- **Declared but never emitted**: an `event` that is declared yet never `emit`ted is a forgotten emission or dead code. Either wire it to the relevant state change or remove it.
+- **Incorrect data**: the logged values must reflect the actual post-conditions (e.g. log the amount actually transferred, after a successful call — not the requested amount). Emit only after the effect succeeds.
+- **Missing `indexed`**: mark key fields (addresses, ids) as `indexed` so off-chain consumers can filter logs efficiently (max 3 indexed topics per event).
+- **No sensitive data**: never log secrets, raw auth hashes, or confidential business logic.
+- NatSpec: accurate `@notice`, `@param`, `@return`; `@dev` for complex logic and security assumptions.
 
 ### Style Guide Compliance
 

--- a/skills/solidity-code-review/SKILL.md
+++ b/skills/solidity-code-review/SKILL.md
@@ -4,7 +4,7 @@ description: Smart contract code review, security best practices, and audit meth
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # Solidity Code Review & Security Guide

--- a/skills/solidity-erc-standards/SKILL.md
+++ b/skills/solidity-erc-standards/SKILL.md
@@ -4,7 +4,7 @@ description: ERC token standard implementation guidelines for Solidity. Use when
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # ERC Token Standard Guidelines

--- a/skills/solidity-foundry-development/SKILL.md
+++ b/skills/solidity-foundry-development/SKILL.md
@@ -4,7 +4,7 @@ description: Foundry development workflow for Solidity smart contracts. Use when
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # Foundry Development Guide

--- a/skills/solidity-gas-optimization/SKILL.md
+++ b/skills/solidity-gas-optimization/SKILL.md
@@ -4,7 +4,7 @@ description: Gas optimization patterns for Solidity smart contracts. Use when op
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # Solidity Gas Optimization

--- a/skills/solidity-hardhat-development/SKILL.md
+++ b/skills/solidity-hardhat-development/SKILL.md
@@ -4,7 +4,7 @@ description: Hardhat 3 development workflow for Solidity smart contracts. Use wh
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.0"
+  version: "0.8.1"
 ---
 
 # Hardhat 3 Development Guide

--- a/src/__tests__/core/ast-detectors.test.ts
+++ b/src/__tests__/core/ast-detectors.test.ts
@@ -293,7 +293,7 @@ describe("events detector", () => {
     expect(detect(code, ["SCWE-063"]).length).toBe(0);
   });
 
-  it("suggests indexed parameters on an emitted multi-field event", () => {
+  it("suggests indexing an unindexed address field on an emitted event", () => {
     const code = `contract Token {
       uint256 public x;
       event Action(address user, uint256 amount, uint256 timestamp);
@@ -306,13 +306,39 @@ describe("events detector", () => {
     expect(results.some((r) => r.name === "Event Missing Indexed Parameters")).toBe(true);
   });
 
-  it("does not suggest indexed when a field is already indexed", () => {
+  it("suggests indexing an unindexed id field on an emitted event", () => {
+    const code = `contract Registry {
+      uint256 public x;
+      event Registered(uint256 tokenId, uint256 value);
+      function register(uint256 tokenId) external {
+        x = tokenId;
+        emit Registered(tokenId, x);
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Event Missing Indexed Parameters")).toBe(true);
+  });
+
+  it("does not suggest indexing when key fields are already indexed", () => {
     const code = `contract Token {
       uint256 public x;
       event Action(address indexed user, uint256 amount, uint256 timestamp);
       function act(uint256 amount) external {
         x = amount;
         emit Action(msg.sender, amount, block.timestamp);
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Event Missing Indexed Parameters")).toBe(false);
+  });
+
+  it("does not suggest indexing amount-only events with no address or id fields", () => {
+    const code = `contract Pool {
+      uint256 public total;
+      event Rebalanced(uint256 supplied, uint256 borrowed, uint256 ratio);
+      function rebalance(uint256 supplied) external {
+        total = supplied;
+        emit Rebalanced(supplied, total, total);
       }
     }`;
     const results = detect(code, ["SCWE-063"]);

--- a/src/__tests__/core/ast-detectors.test.ts
+++ b/src/__tests__/core/ast-detectors.test.ts
@@ -190,7 +190,7 @@ describe("arithmetic detector", () => {
   });
 });
 
-// ─── Code Quality (SCWE-060, SCWE-063, SCWE-067, SCWE-097) ──────
+// ─── Code Quality (SCWE-060, SCWE-067, SCWE-097) ───────────────
 describe("code-quality detector", () => {
   it("detects floating pragma (SCWE-060)", () => {
     const code = `pragma solidity ^0.8.0;
@@ -210,16 +210,6 @@ describe("code-quality detector", () => {
     expect(detectIds(code, ["SCWE-060"])).not.toContain("SCWE-060");
   });
 
-  it("detects missing event emission (SCWE-063)", () => {
-    const code = `contract Config {
-      uint256 public fee;
-      function setFee(uint256 _fee) public {
-        fee = _fee;
-      }
-    }`;
-    expect(detectIds(code, ["SCWE-063"])).toContain("SCWE-063");
-  });
-
   it("detects assert usage (SCWE-067)", () => {
     const code = `contract Invariant {
       function check(uint256 x) public {
@@ -236,6 +226,97 @@ describe("code-quality detector", () => {
       }
     }`;
     expect(detectIds(code, ["SCWE-097"])).toContain("SCWE-097");
+  });
+});
+
+// ─── Event Emission Correctness (SCWE-063) ─────────────────────
+describe("events detector", () => {
+  it("detects missing event emission on a state-changing setter (SCWE-063)", () => {
+    const code = `contract Config {
+      uint256 public fee;
+      function setFee(uint256 _fee) public {
+        fee = _fee;
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Missing Event Emission on State Change")).toBe(true);
+  });
+
+  it("detects missing event emission beyond the set* prefix", () => {
+    const code = `contract Vault {
+      mapping(address => uint256) public balances;
+      function withdraw(uint256 amount) public {
+        balances[msg.sender] -= amount;
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Missing Event Emission on State Change")).toBe(true);
+  });
+
+  it("does not flag a state-changing function that already emits", () => {
+    const code = `contract Config {
+      uint256 public fee;
+      event FeeUpdated(uint256 newFee);
+      function setFee(uint256 _fee) public {
+        fee = _fee;
+        emit FeeUpdated(_fee);
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Missing Event Emission on State Change")).toBe(false);
+  });
+
+  it("does not flag view/pure functions or local-variable writes", () => {
+    const code = `contract Calc {
+      uint256 public total;
+      function preview(uint256 x) public view returns (uint256) {
+        uint256 tmp = x + total;
+        return tmp;
+      }
+    }`;
+    expect(detect(code, ["SCWE-063"]).length).toBe(0);
+  });
+
+  it("detects an event that is declared but never emitted", () => {
+    const code = `contract Token {
+      event Transfer(address indexed from, address indexed to, uint256 value);
+      function noop() external {}
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Declared Event Never Emitted")).toBe(true);
+  });
+
+  it("does not flag events declared in an interface", () => {
+    const code = `interface IToken {
+      event Transfer(address indexed from, address indexed to, uint256 value);
+    }`;
+    expect(detect(code, ["SCWE-063"]).length).toBe(0);
+  });
+
+  it("suggests indexed parameters on an emitted multi-field event", () => {
+    const code = `contract Token {
+      uint256 public x;
+      event Action(address user, uint256 amount, uint256 timestamp);
+      function act(uint256 amount) external {
+        x = amount;
+        emit Action(msg.sender, amount, block.timestamp);
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Event Missing Indexed Parameters")).toBe(true);
+  });
+
+  it("does not suggest indexed when a field is already indexed", () => {
+    const code = `contract Token {
+      uint256 public x;
+      event Action(address indexed user, uint256 amount, uint256 timestamp);
+      function act(uint256 amount) external {
+        x = amount;
+        emit Action(msg.sender, amount, block.timestamp);
+      }
+    }`;
+    const results = detect(code, ["SCWE-063"]);
+    expect(results.some((r) => r.name === "Event Missing Indexed Parameters")).toBe(false);
   });
 });
 

--- a/src/__tests__/tools/vuln-pattern-matcher.test.ts
+++ b/src/__tests__/tools/vuln-pattern-matcher.test.ts
@@ -222,8 +222,10 @@ contract Game {
 pragma solidity 0.8.20;
 contract Safe {
     uint256 private counter;
+    event Incremented(uint256 newValue);
     function increment() external {
         counter += 1;
+        emit Incremented(counter);
     }
     function getCounter() external view returns (uint256) {
         return counter;

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -26,12 +26,13 @@ Protocol-agnostic analysis logic reusable by both MCP and LSP. CLI wrappers, pur
 - `ast-context-filter.ts` — Phase 2 post-filter: reduces regex false positives using AST context (7 SCWE-specific rules)
 - `ast-detector-registry.ts` — `DetectorResult` interface, `ASTDetector` interface, `registerDetector()`, `runASTDetectors()`
 - `ast-utils.ts` — shared utilities: `findExternalCalls()`, `findStateUpdates()`, `checkCEIPattern()`, `findAllFunctions()`, etc.
-- `ast-detectors/` — 8 self-registering detector modules:
+- `ast-detectors/` — 9 self-registering detector modules:
   - `reentrancy.ts` (SCWE-046)
   - `access-control.ts` (SCWE-005, SCWE-016, SCWE-038, SCWE-049)
   - `external-calls.ts` (SCWE-035, SCWE-048, SCWE-059, SCWE-073, SCWE-079)
   - `arithmetic.ts` (SCWE-047, SCWE-074)
-  - `code-quality.ts` (SCWE-060, SCWE-063, SCWE-067, SCWE-097)
+  - `code-quality.ts` (SCWE-060, SCWE-067, SCWE-097)
+  - `events.ts` (SCWE-063 — missing emission, dead events, missing `indexed`)
   - `randomness.ts` (SCWE-024, SCWE-065)
   - `signature.ts` (SCWE-055)
   - `dos.ts` (SCWE-050, SCWE-058, SCWE-071, SCWE-075)

--- a/src/core/ast-detectors/code-quality.ts
+++ b/src/core/ast-detectors/code-quality.ts
@@ -1,6 +1,7 @@
 /**
- * AST detector: Code Quality (SCWE-060, SCWE-063, SCWE-067, SCWE-097)
- * Detects: floating pragma, missing event emission, assert misuse, default visibility.
+ * AST detector: Code Quality (SCWE-060, SCWE-067, SCWE-097)
+ * Detects: floating pragma, assert misuse, default visibility.
+ * Event emission correctness (SCWE-063) lives in its own `events.ts` detector.
  */
 
 import { visit } from "@solidity-parser/parser";
@@ -11,7 +12,7 @@ import {
   isLibraryOrInterfaceOnly,
   getFunctionVisibility,
 } from "../ast-validators.js";
-import { findAllFunctions, hasEmitStatement, findStateUpdates } from "../ast-utils.js";
+import { findAllFunctions } from "../ast-utils.js";
 
 function getLine(node: { loc?: { start: { line: number } } }): number {
   return node.loc?.start.line ?? 0;
@@ -19,7 +20,7 @@ function getLine(node: { loc?: { start: { line: number } } }): number {
 
 registerDetector({
   id: "code-quality",
-  scweIds: ["SCWE-060", "SCWE-063", "SCWE-067", "SCWE-097"],
+  scweIds: ["SCWE-060", "SCWE-067", "SCWE-097"],
   detect(ast: SourceUnit): DetectorResult[] {
     const results: DetectorResult[] = [];
 
@@ -46,27 +47,9 @@ registerDetector({
       }
     }
 
-    // SCWE-063: Missing event emission on state-changing setter functions
+    // SCWE-097: Default function visibility
     const funcs = findAllFunctions(ast);
     for (const func of funcs) {
-      const name = func.name ?? "";
-      const nameLower = name.toLowerCase();
-      const isPublic = func.visibility === "public" || func.visibility === "external";
-
-      if (isPublic && nameLower.startsWith("set") && findStateUpdates(func).length > 0) {
-        if (!hasEmitStatement(func)) {
-          results.push({
-            scweId: "SCWE-063",
-            name: "Missing Event Emission on State Change",
-            severity: "low",
-            line: getLine(func),
-            description: "State-changing functions should emit events for off-chain indexing.",
-            source: "ast",
-          });
-        }
-      }
-
-      // SCWE-097: Default function visibility
       if (getFunctionVisibility(func) === "default" && !func.isConstructor) {
         results.push({
           scweId: "SCWE-097",

--- a/src/core/ast-detectors/events.ts
+++ b/src/core/ast-detectors/events.ts
@@ -7,7 +7,11 @@
  *   - emitted events whose key fields are not indexed for off-chain filtering.
  */
 
-import type { SourceUnit } from "@solidity-parser/parser/src/ast-types.js";
+import type {
+  SourceUnit,
+  VariableDeclaration,
+  ElementaryTypeName,
+} from "@solidity-parser/parser/src/ast-types.js";
 import { registerDetector, type DetectorResult } from "../ast-detector-registry.js";
 import {
   findAllContracts,
@@ -23,8 +27,26 @@ function getLine(node: { loc?: { start: { line: number } } }): number {
   return node.loc?.start.line ?? 0;
 }
 
-/** Events with this many parameters and no indexed field hinder off-chain filtering. */
-const INDEXED_SUGGESTION_THRESHOLD = 3;
+/** Non-anonymous events can hold at most 3 indexed topics (topic0 is the signature). */
+const MAX_INDEXED_TOPICS = 3;
+
+/** camelCase `Id`/`ID` suffix or bare `id`/`_id` — avoids matching "valid"/"paid". */
+const ID_NAME = /(Id|ID)$|^_?id$/;
+
+/**
+ * A parameter worth indexing: an entity key used for off-chain filtering —
+ * an address, or an identifier-named field. Amounts and payloads are not.
+ */
+function isIndexWorthyParam(param: VariableDeclaration): boolean {
+  const typeName = param.typeName;
+  if (
+    typeName?.type === "ElementaryTypeName" &&
+    (typeName as ElementaryTypeName).name === "address"
+  ) {
+    return true;
+  }
+  return param.name != null && ID_NAME.test(param.name);
+}
 
 registerDetector({
   id: "events",
@@ -77,17 +99,23 @@ registerDetector({
           continue;
         }
 
+        if (event.isAnonymous) continue;
         const params = event.parameters;
-        const hasIndexed = params.some((p) => p.isIndexed);
-        if (!event.isAnonymous && params.length >= INDEXED_SUGGESTION_THRESHOLD && !hasIndexed) {
+        const indexedCount = params.filter((p) => p.isIndexed).length;
+        if (indexedCount >= MAX_INDEXED_TOPICS) continue; // no topic slots left
+
+        const candidates = params
+          .filter((p) => !p.isIndexed && isIndexWorthyParam(p))
+          .map((p) => p.name ?? "<unnamed>");
+        if (candidates.length > 0) {
           results.push({
             scweId: "SCWE-063",
             name: "Event Missing Indexed Parameters",
             severity: "low",
             line: getLine(event),
             description:
-              `Event '${event.name}' has ${params.length} parameters but none are indexed. ` +
-              "Mark key fields (addresses, ids) as indexed so off-chain consumers can filter logs.",
+              `Event '${event.name}' has key field(s) not marked indexed: ${candidates.join(", ")}. ` +
+              "Index addresses and ids so off-chain consumers can filter logs (max 3 indexed topics).",
             source: "ast",
           });
         }

--- a/src/core/ast-detectors/events.ts
+++ b/src/core/ast-detectors/events.ts
@@ -1,0 +1,99 @@
+/**
+ * AST detector: Event Emission Correctness (SCWE-063)
+ * Detects events that auditors expect on transaction logic but are missing
+ * or implemented incorrectly:
+ *   - state-changing public/external functions that emit no event,
+ *   - events declared but never emitted anywhere,
+ *   - emitted events whose key fields are not indexed for off-chain filtering.
+ */
+
+import type { SourceUnit } from "@solidity-parser/parser/src/ast-types.js";
+import { registerDetector, type DetectorResult } from "../ast-detector-registry.js";
+import {
+  findAllContracts,
+  findContractFunctions,
+  findStateVariableNames,
+  findStateVarWrites,
+  findEventDefinitions,
+  findEmittedEventNames,
+  hasEmitStatement,
+} from "../ast-utils.js";
+
+function getLine(node: { loc?: { start: { line: number } } }): number {
+  return node.loc?.start.line ?? 0;
+}
+
+/** Events with this many parameters and no indexed field hinder off-chain filtering. */
+const INDEXED_SUGGESTION_THRESHOLD = 3;
+
+registerDetector({
+  id: "events",
+  scweIds: ["SCWE-063"],
+  detect(ast: SourceUnit): DetectorResult[] {
+    const results: DetectorResult[] = [];
+    const emitted = findEmittedEventNames(ast);
+
+    for (const contract of findAllContracts(ast)) {
+      // Interfaces declare events for implementers; libraries rarely emit. Skip both.
+      if (contract.kind === "interface" || contract.kind === "library") continue;
+
+      const stateVars = findStateVariableNames(contract);
+
+      // 1. Missing event emission on state-changing public/external functions.
+      for (const func of findContractFunctions(contract)) {
+        const isPublic = func.visibility === "public" || func.visibility === "external";
+        const isReadOnly = func.stateMutability === "view" || func.stateMutability === "pure";
+        const isSpecial = func.isConstructor || func.isFallback || func.isReceiveEther;
+        if (!isPublic || isReadOnly || isSpecial) continue;
+
+        if (findStateVarWrites(func, stateVars).length > 0 && !hasEmitStatement(func)) {
+          results.push({
+            scweId: "SCWE-063",
+            name: "Missing Event Emission on State Change",
+            severity: "low",
+            line: getLine(func),
+            description:
+              `Function '${func.name ?? "<unnamed>"}' changes contract state but emits no event. ` +
+              "Emit an event for off-chain indexing and auditability of this state transition.",
+            source: "ast",
+          });
+        }
+      }
+
+      // 2 & 3. Event declaration correctness.
+      for (const event of findEventDefinitions(contract)) {
+        if (!emitted.has(event.name)) {
+          // Declared but never emitted — dead event or a forgotten emit on a state change.
+          results.push({
+            scweId: "SCWE-063",
+            name: "Declared Event Never Emitted",
+            severity: "low",
+            line: getLine(event),
+            description:
+              `Event '${event.name}' is declared but never emitted. ` +
+              "Emit it on the relevant state change, or remove it if obsolete.",
+            source: "ast",
+          });
+          continue;
+        }
+
+        const params = event.parameters;
+        const hasIndexed = params.some((p) => p.isIndexed);
+        if (!event.isAnonymous && params.length >= INDEXED_SUGGESTION_THRESHOLD && !hasIndexed) {
+          results.push({
+            scweId: "SCWE-063",
+            name: "Event Missing Indexed Parameters",
+            severity: "low",
+            line: getLine(event),
+            description:
+              `Event '${event.name}' has ${params.length} parameters but none are indexed. ` +
+              "Mark key fields (addresses, ids) as indexed so off-chain consumers can filter logs.",
+            source: "ast",
+          });
+        }
+      }
+    }
+
+    return results;
+  },
+});

--- a/src/core/ast-detectors/index.ts
+++ b/src/core/ast-detectors/index.ts
@@ -9,6 +9,7 @@ import "./access-control.js";
 import "./external-calls.js";
 import "./arithmetic.js";
 import "./code-quality.js";
+import "./events.js";
 import "./randomness.js";
 import "./signature.js";
 import "./dos.js";

--- a/src/core/ast-utils.ts
+++ b/src/core/ast-utils.ts
@@ -9,6 +9,10 @@ import type {
   SourceUnit,
   FunctionDefinition,
   ContractDefinition,
+  EventDefinition,
+  StateVariableDeclaration,
+  EmitStatement,
+  Expression,
   BaseASTNode,
   FunctionCall,
   MemberAccess,
@@ -143,6 +147,96 @@ export function hasFunctionCall(func: FunctionDefinition, name: string): boolean
 /** Check if a function body contains a delegatecall. */
 export function hasDelegatecall(func: FunctionDefinition): boolean {
   return findExternalCalls(func).some((c) => c.kind === "delegatecall");
+}
+
+/** Find all FunctionDefinition nodes declared directly within a contract. */
+export function findContractFunctions(contract: ContractDefinition): FunctionDefinition[] {
+  const funcs: FunctionDefinition[] = [];
+  visit(contract, {
+    FunctionDefinition: (node) => {
+      funcs.push(node);
+    },
+  });
+  return funcs;
+}
+
+/** Collect the names of all state variables declared in a contract. */
+export function findStateVariableNames(contract: ContractDefinition): Set<string> {
+  const names = new Set<string>();
+  for (const node of contract.subNodes) {
+    if (node.type === "StateVariableDeclaration") {
+      for (const v of (node as StateVariableDeclaration).variables) {
+        if (v.name) names.add(v.name);
+      }
+    }
+  }
+  return names;
+}
+
+/** Find all EventDefinition nodes declared within a contract. */
+export function findEventDefinitions(contract: ContractDefinition): EventDefinition[] {
+  const events: EventDefinition[] = [];
+  visit(contract, {
+    EventDefinition: (node) => {
+      events.push(node);
+    },
+  });
+  return events;
+}
+
+/** Collect the names of every event emitted anywhere in the source unit. */
+export function findEmittedEventNames(ast: SourceUnit): Set<string> {
+  const names = new Set<string>();
+  visit(ast, {
+    EmitStatement: (node) => {
+      const expr = (node as EmitStatement).eventCall.expression;
+      if (expr.type === "Identifier") names.add(expr.name);
+    },
+  });
+  return names;
+}
+
+/** Resolve the root identifier of an assignable expression (e.g. `a.b[c]` → `a`). */
+function baseIdentifierName(node: Expression): string | null {
+  switch (node.type) {
+    case "Identifier":
+      return node.name;
+    case "IndexAccess":
+      return baseIdentifierName(node.base);
+    case "MemberAccess":
+      return baseIdentifierName(node.expression);
+    default:
+      return null;
+  }
+}
+
+const ASSIGNMENT_OPERATORS = new Set(["=", "+=", "-=", "*=", "/=", "%=", "|=", "&=", "^="]);
+
+/**
+ * Find assignments within a function whose target resolves to a state variable.
+ * More precise than findStateUpdates: ignores writes to local variables.
+ */
+export function findStateVarWrites(
+  func: FunctionDefinition,
+  stateVarNames: Set<string>,
+): StateUpdateInfo[] {
+  if (!func.body || stateVarNames.size === 0) return [];
+  const updates: StateUpdateInfo[] = [];
+
+  visit(func.body, {
+    ExpressionStatement: (node) => {
+      const expr = node.expression;
+      if (!expr || expr.type !== "BinaryOperation" || !ASSIGNMENT_OPERATORS.has(expr.operator)) {
+        return;
+      }
+      const base = baseIdentifierName(expr.left);
+      if (base && stateVarNames.has(base)) {
+        updates.push({ line: getLine(node), text: expr.operator });
+      }
+    },
+  });
+
+  return updates;
 }
 
 /** Extract all member access patterns like block.timestamp, tx.origin. */


### PR DESCRIPTION
## Summary

Adds a dedicated event emission correctness detector (SCWE-063) and bumps to v0.8.1.

### What
- New `events.ts` AST detector, split out of `code-quality.ts`:
  - **Missing emission** — state-changing public/external functions that write a state variable but emit no event (broadened from the `set*` heuristic to true state-variable writes).
  - **Declared but never emitted** — dead events / forgotten `emit`.
  - **Missing `indexed`** — emitted events whose key fields (address-typed or id-named) are not indexed, only when an indexed topic slot is still free. Amount/payload-only events are not flagged.
- Skips interfaces and libraries to avoid false positives.
- Updates the `solidity-code-review` skill (Events & NatSpec section) and detector docs.
- `pnpm version patch` → 0.8.1 (synced across all 6 SKILL.md).

### Verification
- 734 tests pass, typecheck + lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)