### PR TITLE
release: v0.8.2 — style check fixes (function ordering, leading-underscore constants)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: true # data/owasp-scs required for knowledge tests
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true # data/owasp-scs required for knowledge tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           submodules: true # data/owasp-scs submodule required for build/test
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: true # data/owasp-scs submodule required for build/test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-agent-toolkit",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "MCP server providing Solidity smart contract security analysis tools, OWASP knowledge base, and development utilities for AI agents",
   "repository": {
     "type": "git",

--- a/skills/solidity-adversarial-analysis/SKILL.md
+++ b/skills/solidity-adversarial-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Adversarial scenario analysis and threat modeling for Solidity smar
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Solidity Adversarial Scenario Analysis

--- a/skills/solidity-code-review/SKILL.md
+++ b/skills/solidity-code-review/SKILL.md
@@ -4,7 +4,7 @@ description: Smart contract code review, security best practices, and audit meth
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Solidity Code Review & Security Guide

--- a/skills/solidity-erc-standards/SKILL.md
+++ b/skills/solidity-erc-standards/SKILL.md
@@ -4,7 +4,7 @@ description: ERC token standard implementation guidelines for Solidity. Use when
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # ERC Token Standard Guidelines

--- a/skills/solidity-foundry-development/SKILL.md
+++ b/skills/solidity-foundry-development/SKILL.md
@@ -4,7 +4,7 @@ description: Foundry development workflow for Solidity smart contracts. Use when
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Foundry Development Guide

--- a/skills/solidity-gas-optimization/SKILL.md
+++ b/skills/solidity-gas-optimization/SKILL.md
@@ -4,7 +4,7 @@ description: Gas optimization patterns for Solidity smart contracts. Use when op
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Solidity Gas Optimization

--- a/skills/solidity-hardhat-development/SKILL.md
+++ b/skills/solidity-hardhat-development/SKILL.md
@@ -4,7 +4,7 @@ description: Hardhat 3 development workflow for Solidity smart contracts. Use wh
 license: MIT
 metadata:
   author: whackur (whackur@gmail.com)
-  version: "0.8.1"
+  version: "0.8.2"
 ---
 
 # Hardhat 3 Development Guide

--- a/src/__tests__/tools/style-guide.test.ts
+++ b/src/__tests__/tools/style-guide.test.ts
@@ -226,6 +226,41 @@ describe("Style Guide", () => {
       const violations = FUNCTION_ORDER_RULE.check(code, code.split("\n"));
       expect(violations).toHaveLength(1);
     });
+
+    it("detects wrong ordering with multi-line function bodies", () => {
+      const code = [
+        "contract Test {",
+        "    function _helper() internal pure returns (uint256) {",
+        "        return 1;",
+        "    }",
+        "",
+        "    function publicEntry() external pure returns (uint256) {",
+        "        return _helper();",
+        "    }",
+        "}",
+      ].join("\n");
+      const violations = FUNCTION_ORDER_RULE.check(code, code.split("\n"));
+      expect(violations).toHaveLength(1);
+      expect(violations[0].ruleId).toBe("style-function-order");
+      expect(violations[0].message).toContain("external");
+      expect(violations[0].line).toBe(6);
+    });
+
+    it("passes correct ordering with multi-line function bodies", () => {
+      const code = [
+        "contract Test {",
+        "    function publicEntry() external pure returns (uint256) {",
+        "        return _helper();",
+        "    }",
+        "",
+        "    function _helper() internal pure returns (uint256) {",
+        "        return 1;",
+        "    }",
+        "}",
+      ].join("\n");
+      const violations = FUNCTION_ORDER_RULE.check(code, code.split("\n"));
+      expect(violations).toHaveLength(0);
+    });
   });
 
   describe("MODIFIER_ORDER_RULE", () => {
@@ -320,6 +355,20 @@ describe("Style Guide", () => {
       const code = "    uint256 public constant MAX_SUPPLY = 1000;";
       const violations = NAMING_CONSTANT_RULE.check(code, code.split("\n"));
       expect(violations).toHaveLength(0);
+    });
+
+    it("allows a single leading underscore on UPPER_CASE constants", () => {
+      const code = '    string private constant _VERSION = "1.0";';
+      const violations = NAMING_CONSTANT_RULE.check(code, code.split("\n"));
+      expect(violations).toHaveLength(0);
+    });
+
+    it("flags leading-underscore constants that are not UPPER_CASE with a non-noop fix", () => {
+      const code = "    uint256 private constant _maxSupply = 1000;";
+      const violations = NAMING_CONSTANT_RULE.check(code, code.split("\n"));
+      expect(violations).toHaveLength(1);
+      expect(violations[0].fix).toBe("Rename to _MAX_SUPPLY");
+      expect(violations[0].fix).not.toBe("Rename to _maxSupply");
     });
   });
 

--- a/src/knowledge/style-rules.ts
+++ b/src/knowledge/style-rules.ts
@@ -221,6 +221,11 @@ export const FUNCTION_ORDER_RULE: StyleRule = {
         inContract = true;
       }
 
+      // Depth BEFORE counting this line's braces. A contract's direct members
+      // (functions/constructor) start at depth 1; using the post-count depth
+      // misses any member whose opening brace is on the declaration line.
+      const depthAtLineStart = braceDepth;
+
       for (const ch of trimmed) {
         if (ch === "{") braceDepth++;
         if (ch === "}") braceDepth--;
@@ -240,9 +245,10 @@ export const FUNCTION_ORDER_RULE: StyleRule = {
           }
         }
         functionDefs.length = 0;
+        continue;
       }
 
-      if (!inContract || braceDepth < 1) continue;
+      if (!inContract || depthAtLineStart !== 1) continue;
 
       if (/^\s*constructor\s*\(/.test(lines[i])) {
         functionDefs.push({ visibility: "constructor", line: i + 1, order: 0 });
@@ -259,7 +265,7 @@ export const FUNCTION_ORDER_RULE: StyleRule = {
       }
 
       const funcMatch = lines[i].match(/^\s*function\s+\w+\s*\(/);
-      if (funcMatch && braceDepth === 1) {
+      if (funcMatch) {
         const lineStr = lines[i];
         let visibility = "internal";
         if (/\bexternal\b/.test(lineStr)) visibility = "external";
@@ -453,7 +459,9 @@ export const NAMING_CONSTANT_RULE: StyleRule = {
   description: "Constants should use UPPER_CASE_WITH_UNDERSCORES",
   check: (_code: string, lines: string[]): StyleViolation[] => {
     const violations: StyleViolation[] = [];
-    const upperSnake = /^[A-Z][A-Z0-9_]*$/;
+    // A single leading underscore is a valid private/internal visibility marker,
+    // not a casing violation (e.g. `_VERSION`). Allow it before the UPPER_CASE body.
+    const upperSnake = /^_?[A-Z][A-Z0-9_]*$/;
 
     for (let i = 0; i < lines.length; i++) {
       if (isInsideBlockComment(lines, i)) continue;


### PR DESCRIPTION
## Summary

Fixes two confirmed `check_code_style` issues reported against v0.8.1.

### Issue 1 — function ordering not detected (multi-line bodies)
`FUNCTION_ORDER_RULE` already existed but never fired for real contracts: it checked `braceDepth === 1` *after* counting the declaration line's opening brace, so any member with a multi-line body (depth → 2) was never recorded. Existing tests only used single-line `{}` bodies, which masked the bug. Now we capture brace depth at line start to identify direct contract members.

### Issue 2 — leading-underscore constant false positive + no-op fix
`NAMING_CONSTANT_RULE` flagged valid private/internal constants like `_VERSION` and suggested `Rename to _VERSION` (identical to input). The UPPER_CASE regex now allows a single optional leading underscore before the uppercase body.

## Tests
- Added regression tests for both (multi-line ordering, `_VERSION` pass, `_maxSupply` → `_MAX_SUPPLY` non-noop fix).
- Full suite: 738 passed, 5 skipped. typecheck + lint clean.

## Release
Version bumped to 0.8.2 (`pnpm version patch`, syncs all SKILL.md). Tag `v0.8.2` pushed — npm publish triggered.